### PR TITLE
Fix broken references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -47,7 +47,7 @@ urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML;
     type: dfn; url: #calling-scripts; text: calling scripts;
     type: dfn; url: #list-of-the-descendant-browsing-contexts; text: list of the descendant browsing contexts;
     type: dfn; url: #ancestor-browsing-context; text: ancestor;
-    type: dfn; url: #browsing-context-group-set; text: browsing-context-group-set
+    type: dfn; url: #browsing-context-group-set; text: browsing context group set
     type: dfn; url: #script-evaluation-environment-settings-object-set; text: script evaluation environment settings object set
     type: dfn; url: #integration-with-the-javascript-agent-cluster-formalism; text: agent cluster
     type: dfn; url: #concept-task-document; for: task; text: document;


### PR DESCRIPTION
* "Unit of related browsing contexts" was removed from the HTML spec in 2019 (https://github.com/whatwg/html/pull/4350)

* "Report task end time" moved to LONG-ANIMATION-FRAMES and has been renamed "Record task end time"

Closes: #108


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/longtasks/pull/141.html" title="Last updated on May 24, 2024, 7:40 PM UTC (b31279a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/longtasks/141/199e287...b31279a.html" title="Last updated on May 24, 2024, 7:40 PM UTC (b31279a)">Diff</a>